### PR TITLE
Adds simple d.ts file for TypeScript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,32 @@
+let glob: Glob;
+
+interface Glob {
+  (path: string, opts?: {
+    cwd?: string;
+    root?: string;
+    dot?: boolean;
+    nomount?: boolean;
+    mark?: boolean;
+    nosort?: boolean;
+    stat?: boolean;
+    silent?: boolean;
+    strict?: boolean;
+    cache?: boolean;
+    statCache?: boolean;
+    symLinks?: boolean;
+    nounique?: boolean;
+    nonull?: boolean;
+    debug?: boolean;
+    nobrace?: boolean;
+    noglobstar?: boolean;
+    noext?: boolean;
+    nocase?: boolean;
+    matchBase?: boolean;
+    nodir?: boolean;
+    ignore?: string | Array<string>;
+    follow?: boolean;
+    realpath?: boolean;
+  }): Promise<Array<string>>;
+}
+
+export = glob;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "coverage/**"
     ]
   },
+  "typings": "lib/index.d.ts",
   "devDependencies": {
     "codeclimate-test-reporter": "^0.3.1",
     "echint": "^1.5.3",


### PR DESCRIPTION
This adds a simple TypeScript definition. There's probably a better way of doing this — namely, adding a typings.json file, pulling in the parent `glob`'s d.ts, and then extending that — but this'll suffice for most purposes.